### PR TITLE
Fixed Scene Selection

### DIFF
--- a/AutoHeightAdjuster/Plugin.cs
+++ b/AutoHeightAdjuster/Plugin.cs
@@ -24,7 +24,7 @@ namespace BeatSaberAutoHeightAdjuster
         private void SceneManager_sceneLoaded(Scene newScene, LoadSceneMode arg1)
         {
             Log("Scene Change");
-            if (newScene.name != "Menu")
+            if (newScene.name == "GameCore")
             {
                 Log("Measure player height");
                 var mainSettingModel = Resources.FindObjectsOfTypeAll<MainSettingsModel>().FirstOrDefault();


### PR DESCRIPTION
I think you meant to do this. The way you currently have it it fires on every scene except menu, there's multiple scenes other than GameCore and Menu. This is breaking other mods. 